### PR TITLE
Replace unpinned actions with pinned action

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,35 +1,33 @@
 name: build
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
-
+    branches: ["main"]
 jobs:
   build:
     permissions:
-        id-token: write
-        packages: write
-        contents: write
+      id-token: write
+      packages: write
+      contents: write
     runs-on: ubuntu-latest
     steps:
-        - name: Check out code
-          uses: actions/checkout@v4
-        - name: Set up Go
-          uses: actions/setup-go@v5
-          with:
-            go-version: '1.21'
-        - name: Run Go build
-          run: |
-            go build -v -o bad-go-binary ./...
-        - name: Sign artifact
-          uses: github-early-access/generate-build-provenance@main
-          with:
-            subject-path: '${{ github.workspace }}/bad-go-binary'
-        - name: Upload artifact
-          uses: actions/upload-artifact@v3
-          with:
-            name: bad-go-binary-artifact
-            path: bad-go-binary
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      - name: Run Go build
+        run: |
+          go build -v -o bad-go-binary ./...
+      - name: Sign artifact
+        uses: github-early-access/generate-build-provenance@3bfd91bfee170b89e21d845828cbe80581656edd # main
+        with:
+          subject-path: '${{ github.workspace }}/bad-go-binary'
+      - name: Upload artifact
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+        with:
+          name: bad-go-binary-artifact
+          path: bad-go-binary

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -58,7 +58,7 @@ jobs:
           #cache-to: type=gha,mode=max
       - name: generate build provenance
         if: ${{ github.event_name != 'pull_request' }}
-        uses: github-early-access/generate-build-provenance@main
+        uses: github-early-access/generate-build-provenance@3bfd91bfee170b89e21d845828cbe80581656edd # main
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,16 +1,14 @@
 # Adapted from https://raw.githubusercontent.com/actions/starter-workflows/main/code-scanning/codeql.yml
 name: "CodeQL"
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
     - cron: '30 4-6 * * *'
-
 jobs:
   analyze:
     name: Analyze
@@ -25,7 +23,6 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -34,28 +31,24 @@ jobs:
         # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
         # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@1b8143f79bd07b5e00e176276a146c18ffdf38b7 # v2
         with:
           languages: ${{ matrix.language }}
-            # If you wish to specify custom queries, you can do so here or in a config file.
-            # By default, queries listed here will override any specified in a config file.
-            # Prefix the list here with "+" to use these queries and those in the config file.
-            
-            # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-            # queries: security-extended,security-and-quality
-
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
 
+        uses: github/codeql-action/autobuild@c677f54dec034285092646c706b2eaac100e3c20 # v3
       # Command-line programs to run using the OS shell.
       # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
@@ -65,8 +58,7 @@ jobs:
       # - run: |
       #     echo "Run, Build Application using script"
       #     ./location_of_script_within_repo/buildscript.sh
-
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@c677f54dec034285092646c706b2eaac100e3c20 # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -7,13 +7,13 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 jobs:
-    call-workflow-build-docker:
-        uses: jakubtestorg/workflows/.github/workflows/build-docker.yml@main
-        with:
-            push-to-registry: true
-        permissions:
-            contents: read
-            packages: write
-            # This is used to complete the identity challenge
-            # with sigstore/fulcio when running outside of PRs.
-            id-token: write
+  call-workflow-build-docker:
+    uses: jakubtestorg/workflows/.github/workflows/build-docker.yml@2b37a3e12a98345f6653f7821d440cbcb02e6587 # main
+    with:
+      push-to-registry: true
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write


### PR DESCRIPTION
This is a Minder automated pull request.

This pull request replaces references to actions by tag to references to actions by SHA.

Verifies that any actions use pinned tags
Pinning an action to a full length commit SHA is currently the only way to use
an action as an immutable release. Pinning to a particular SHA helps mitigate
the risk of a bad actor adding a backdoor to the action's repository, as they
would need to generate a SHA-1 collision for a valid Git object payload.
When selecting a SHA, you should verify it is from the action's repository
and not a repository fork.

For more information, see
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
